### PR TITLE
Fix/develop commits

### DIFF
--- a/.github/workflows/pytest-workflow.yml
+++ b/.github/workflows/pytest-workflow.yml
@@ -149,6 +149,8 @@ jobs:
           - profile: "conda"
             tags: subworkflows/bcl_demultiplex
           - profile: "conda"
+            tags: subworkflows/vcf_annotate_ensemblvep_snpeff
+          - profile: "conda"
             tags: subworkflows/vcf_annotate_ensemblvep
           - profile: "conda"
             tags: subworkflows/fasta_clean_fcs

--- a/modules/nf-core/bcftools/query/main.nf
+++ b/modules/nf-core/bcftools/query/main.nf
@@ -34,7 +34,7 @@ process BCFTOOLS_QUERY {
         $samples_file \\
         $args \\
         $vcf \\
-        > ${prefix}.txt
+        > ${prefix}.${suffix}
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/bcftools/query/main.nf
+++ b/modules/nf-core/bcftools/query/main.nf
@@ -1,6 +1,6 @@
 process BCFTOOLS_QUERY {
     tag "$meta.id"
-    label 'process_medium'
+    label 'process_single'
 
     conda "bioconda::bcftools=1.17"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
@@ -29,12 +29,12 @@ process BCFTOOLS_QUERY {
     def samples_file =  samples ? "--samples-file ${samples}" : ""
     """
     bcftools query \\
-        --output ${prefix}.txt \\
         $regions_file \\
         $targets_file \\
         $samples_file \\
         $args \\
-        $vcf
+        $vcf \\
+        > ${prefix}.txt
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/tabix/bgziptabix/main.nf
+++ b/modules/nf-core/tabix/bgziptabix/main.nf
@@ -5,7 +5,7 @@ process TABIX_BGZIPTABIX {
     conda "bioconda::tabix=1.11"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/tabix:1.11--hdfd78af_0' :
-        'quay.io/biocontainers/tabix:1.11--hdfd78af_0' }"
+        'biocontainers/tabix:1.11--hdfd78af_0' }"
 
     input:
     tuple val(meta), path(input)

--- a/modules/nf-core/tabix/bgziptabix/main.nf
+++ b/modules/nf-core/tabix/bgziptabix/main.nf
@@ -5,13 +5,14 @@ process TABIX_BGZIPTABIX {
     conda "bioconda::tabix=1.11"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/tabix:1.11--hdfd78af_0' :
-        'biocontainers/tabix:1.11--hdfd78af_0' }"
+        'quay.io/biocontainers/tabix:1.11--hdfd78af_0' }"
 
     input:
     tuple val(meta), path(input)
 
     output:
-    tuple val(meta), path("*.gz"), path("*.tbi"), emit: gz_tbi
+    tuple val(meta), path("*.gz"), path("*.tbi"), optional: true, emit: gz_tbi
+    tuple val(meta), path("*.gz"), path("*.csi"), optional: true, emit: gz_csi
     path  "versions.yml" ,                        emit: versions
 
     when:
@@ -36,6 +37,7 @@ process TABIX_BGZIPTABIX {
     """
     touch ${prefix}.${input.getExtension()}.gz
     touch ${prefix}.${input.getExtension()}.gz.tbi
+    touch ${prefix}.${input.getExtension()}.gz.csi
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/tabix/bgziptabix/meta.yml
+++ b/modules/nf-core/tabix/bgziptabix/meta.yml
@@ -37,9 +37,14 @@ output:
       type: file
       description: tabix index file
       pattern: "*.{gz.tbi}"
+  - csi:
+      type: file
+      description: tabix alternate index file
+      pattern: "*.{gz.csi}"
   - versions:
       type: file
       description: File containing software versions
       pattern: "versions.yml"
 authors:
   - "@maxulysse"
+  - "@DLBPointon"

--- a/subworkflows/nf-core/vcf_annotate_ensemblvep_snpeff/main.nf
+++ b/subworkflows/nf-core/vcf_annotate_ensemblvep_snpeff/main.nf
@@ -1,0 +1,191 @@
+//
+// Run VEP and/or SNPEFF to annotate VCF files
+//
+
+include { ENSEMBLVEP_VEP         } from '../../../modules/nf-core/ensemblvep/vep/main'
+include { SNPEFF_SNPEFF          } from '../../../modules/nf-core/snpeff/snpeff/main'
+include { TABIX_TABIX            } from '../../../modules/nf-core/tabix/tabix/main'
+include { BCFTOOLS_PLUGINSCATTER } from '../../../modules/nf-core/bcftools/pluginscatter/main'
+include { BCFTOOLS_CONCAT        } from '../../../modules/nf-core/bcftools/concat/main'
+include { BCFTOOLS_SORT          } from '../../../modules/nf-core/bcftools/sort/main'
+
+workflow VCF_ANNOTATE_ENSEMBLVEP_SNPEFF {
+    take:
+    ch_vcf                      // channel: [ val(meta), path(vcf), path(tbi), [path(file1), path(file2)...] ]
+    ch_fasta                    // channel: [ val(meta2), path(fasta) ] (optional)
+    val_vep_genome              //   value: genome to use
+    val_vep_species             //   value: species to use
+    val_vep_cache_version       //   value: cache version to use
+    ch_vep_cache                // channel: [ path(cache) ] (optional)
+    ch_vep_extra_files          // channel: [ path(file1), path(file2)... ] (optional)
+    val_snpeff_db               //   value: the db version to use for snpEff
+    ch_snpeff_cache             // channel: [ path(cache) ] (optional)
+    val_tools_to_use            //   value: a list of tools to use options are: ["ensemblvep", "snpeff"]
+    val_sites_per_chunk         //   value: the amount of variants per scattered VCF
+
+    main:
+    ch_versions = Channel.empty()
+
+    // Check if val_sites_per_chunk is set and scatter if it is
+    if(val_sites_per_chunk) {
+        //
+        // Prepare the input VCF channel for scattering (split VCFs from custom files)
+        //
+
+        ch_input = ch_vcf
+            .multiMap { meta, vcf, tbi, custom_files ->
+                vcf:    [ meta, vcf, tbi ]
+                custom: [ meta, custom_files ]
+            }
+
+        //
+        // Scatter the input VCFs into multiple VCFs. These VCFs contain the amount of variants
+        // specified by `val_sites_per_chunk`. The lower this value is, the more files will be created
+        //
+
+        BCFTOOLS_PLUGINSCATTER(
+            ch_input.vcf,
+            val_sites_per_chunk,
+            [],
+            [],
+            [],
+            []
+        )
+        ch_versions = ch_versions.mix(BCFTOOLS_PLUGINSCATTER.out.versions.first())
+
+        //
+        // Run the annotation with EnsemblVEP
+        //
+
+        ch_scatter = BCFTOOLS_PLUGINSCATTER.out.scatter
+            .map { meta, vcfs ->
+                // This checks if multiple files were created using the scatter process
+                // If multiple files are created, a list will be made as output of the process
+                // So if the output isn't a list, there is always one file and if there is a list,
+                // the amount of files in the list gets counted by .size()
+                is_list = vcfs instanceof ArrayList
+                count = is_list ? vcfs.size() : 1
+                [ meta, is_list ? vcfs : [vcfs], count ]
+                // Channel containing the list of VCFs and the size of this list
+            }
+            .transpose(by:1) // Transpose on the VCFs => Creates an entry for each VCF in the list
+            .combine(ch_input.custom, by: 0) // Re-add the sample specific custom files
+            .multiMap { meta, vcf, count, custom_files ->
+                // Define the new ID. The `_annotated` is to disambiguate the VEP output with its input
+                new_id = "${meta.id}${vcf.name.replace(meta.id,"").tokenize(".")[0]}_annotated" as String
+                new_meta = meta + [id:new_id]
+
+                // Create channels: one with the VEP input and one with the original ID and count of scattered VCFs
+                input:  [ new_meta, vcf, custom_files ]
+                count:  [ new_meta, meta.id, count ]
+            }
+
+        ch_vep_input = ch_scatter.input
+    } else {
+        // Use the normal input when no scattering has to be performed
+        ch_vep_input = ch_vcf.map { meta, vcf, tbi, files -> [ meta, vcf, files ] }
+    }
+
+    // Annotate with ensemblvep if it's part of the requested tools
+    if("ensemblvep" in val_tools_to_use){
+        ENSEMBLVEP_VEP(
+            ch_vep_input,
+            val_vep_genome,
+            val_vep_species,
+            val_vep_cache_version,
+            ch_vep_cache,
+            ch_fasta,
+            ch_vep_extra_files
+        )
+        ch_versions = ch_versions.mix(ENSEMBLVEP_VEP.out.versions.first())
+
+        ch_vep_output  = ENSEMBLVEP_VEP.out.vcf
+        ch_vep_reports = ENSEMBLVEP_VEP.out.report
+    } else {
+        ch_vep_output  = ch_vep_input.map { meta, vcf, files -> [ meta, vcf ] }
+        ch_vep_reports = Channel.empty()
+    }
+
+    // Annotate with snpeff if it's part of the requested tools
+    if("snpeff" in val_tools_to_use){
+        SNPEFF_SNPEFF(
+            ch_vep_output,
+            val_snpeff_db,
+            ch_snpeff_cache
+        )
+        ch_versions = ch_versions.mix(SNPEFF_SNPEFF.out.versions.first())
+
+        ch_snpeff_output  = SNPEFF_SNPEFF.out.vcf
+        ch_snpeff_reports = SNPEFF_SNPEFF.out.report
+        ch_snpeff_html    = SNPEFF_SNPEFF.out.summary_html
+        ch_snpeff_genes   = SNPEFF_SNPEFF.out.genes_txt
+    } else {
+        ch_snpeff_output  = ch_vep_output
+        ch_snpeff_reports = Channel.empty()
+        ch_snpeff_html    = Channel.empty()
+        ch_snpeff_genes   = Channel.empty()
+    }
+
+    // Gather the files back together if they were scattered
+    if(val_sites_per_chunk) {
+        //
+        // Concatenate the VCFs back together with bcftools concat
+        //
+
+        ch_concat_input = ch_snpeff_output
+            .join(ch_scatter.count, failOnDuplicate:true, failOnMismatch:true)
+            .map { meta, vcf, id, count ->
+                new_meta = meta + [id:id]
+                [ groupKey(new_meta, count), vcf ]
+            }
+            .groupTuple() // Group the VCFs which need to be concatenated
+            .map { it + [[]] }
+
+        BCFTOOLS_CONCAT(
+            ch_concat_input
+        )
+        ch_versions = ch_versions.mix(BCFTOOLS_CONCAT.out.versions.first())
+
+        //
+        // Sort the concatenate output (bcftools concat is unable to do this on its own)
+        //
+
+        BCFTOOLS_SORT(
+            BCFTOOLS_CONCAT.out.vcf
+        )
+        ch_versions = ch_versions.mix(BCFTOOLS_SORT.out.versions.first())
+
+        ch_ready_vcfs = BCFTOOLS_SORT.out.vcf
+    } else {
+        ch_ready_vcfs = ch_snpeff_output
+    }
+
+    //
+    // Index the resulting bgzipped VCFs
+    //
+
+    ch_tabix_input = ch_ready_vcfs
+        .branch { meta, vcf ->
+            // Split the bgzipped VCFs from the unzipped VCFs (only bgzipped VCFs should be indexed)
+            bgzip: vcf.extension == "gz"
+            unzip: true
+                return [ meta, vcf, [] ]
+        }
+
+    TABIX_TABIX(
+        ch_tabix_input.bgzip
+    )
+    ch_versions = ch_versions.mix(TABIX_TABIX.out.versions)
+
+    ch_vcf_tbi = ch_tabix_input.bgzip
+        .join(TABIX_TABIX.out.tbi, failOnDuplicate: true, failOnMismatch: true)
+        .mix(ch_tabix_input.unzip)
+
+    emit:
+    vcf_tbi         = ch_vcf_tbi        // channel: [ val(meta), path(vcf), path(tbi) ]
+    vep_reports     = ch_vep_reports    // channel: [ path(html) ]
+    snpeff_reports  = ch_snpeff_reports // channel: [ path(csv) ]
+    snpeff_html     = ch_snpeff_html    // channel: [ path(html) ]
+    snpeff_genes    = ch_snpeff_genes   // channel: [ path(genes) ]
+    versions        = ch_versions       // channel: [ versions.yml ]
+}

--- a/subworkflows/nf-core/vcf_annotate_ensemblvep_snpeff/meta.yml
+++ b/subworkflows/nf-core/vcf_annotate_ensemblvep_snpeff/meta.yml
@@ -1,0 +1,73 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/subworkflows/yaml-schema.json
+name: vcf_annotate_ensemblvep_snpeff
+description: |
+  Perform annotation with ensemblvep and/or snpeff and bgzip + tabix index the resulting VCF file. This subworkflow uses the scatter-gather method to run VEP/snpEff in parallel to increase throughput. The input VCF is split into multiple smaller VCFs of fixed size, which are annotated separately and concatenated back together to a single output file per sample. Only VCF/BCF outputs are currently supported.
+keywords:
+  - vcf
+  - annotation
+  - ensemblvep
+  - snpeff
+modules:
+  - ensemblvep/vep
+  - snpeff/snpeff
+  - tabix/tabix
+  - bcftools/pluginscatter
+  - bcftools/concat
+input:
+  - ch_vcf:
+      description: |
+        vcf file to annotate
+        Structure: [ val(meta), path(vcf), path(tbi) ]
+  - ch_fasta:
+      description: |
+        Reference genome fasta file (optional)
+        Structure: [ val(meta2), path(fasta) ]
+  - val_vep_genome:
+      type: string
+      description: genome to use for ensemblvep
+  - val_vep_species:
+      type: string
+      description: species to use for ensemblvep
+  - val_vep_cache_version:
+      type: integer
+      description: cache version to use for ensemblvep
+  - ch_vep_cache:
+      description: |
+        the root cache folder for ensemblvep (optional)
+        Structure: [ path(cache) ]
+  - ch_vep_extra_files:
+      description: |
+        any extra files needed by plugins for ensemblvep (optional)
+        Structure: [ path(file1), path(file2)... ]
+  - val_snpeff_db:
+      type: string
+      description: database to use for snpeff
+  - ch_snpeff_cache:
+      description: |
+        the root cache folder for snpeff (optional)
+        Structure: [ path(cache) ]
+  - val_tools_to_use:
+      type: list
+      description: The tools to use. Options => '["ensemblvep", "snpeff"]'
+  - val_sites_per_chunk:
+      type: integer
+      description: |
+        The amount of variants per scattered VCF.
+        Set this value to `null`, `[]` or `false` to disable scattering.
+output:
+  - vcf_tbi:
+      description: |
+        Compressed vcf file + tabix index
+        Structure: [ val(meta), path(vcf), path(tbi) ]
+  - reports:
+      type: file
+      description: html reports
+      pattern: "*.html"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+authors:
+  - "@maxulysse"
+  - "@matthdsm"
+  - "@nvnieuwk"

--- a/tests/config/pytest_modules.yml
+++ b/tests/config/pytest_modules.yml
@@ -3736,6 +3736,10 @@ subworkflows/vcf_annotate_ensemblvep:
   - subworkflows/nf-core/vcf_annotate_ensemblvep/**
   - tests/subworkflows/nf-core/vcf_annotate_ensemblvep/**
 
+subworkflows/vcf_annotate_ensemblvep_snpeff:
+  - subworkflows/nf-core/vcf_annotate_ensemblvep_snpeff/**
+  - tests/subworkflows/nf-core/vcf_annotate_ensemblvep_snpeff/**
+
 subworkflows/vcf_annotate_snpeff:
   - subworkflows/nf-core/vcf_annotate_snpeff/**
   - tests/subworkflows/nf-core/vcf_annotate_snpeff/**

--- a/tests/modules/nf-core/bcftools/query/test.yml
+++ b/tests/modules/nf-core/bcftools/query/test.yml
@@ -1,17 +1,19 @@
-- name: bcftools query
+- name: bcftools query test_bcftools_query
   command: nextflow run ./tests/modules/nf-core/bcftools/query -entry test_bcftools_query -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/bcftools/query/nextflow.config
   tags:
     - bcftools/query
     - bcftools
   files:
     - path: output/bcftools/out.txt
-      md5sum: c32a6d28f185822d8fe1eeb7e42ec155
+      md5sum: 51d135de052f3bcef50dcd6b74806094
+    - path: output/bcftools/versions.yml
 
-- name: bcftools query with optional files
+- name: bcftools query test_bcftools_query_with_optional_files
   command: nextflow run ./tests/modules/nf-core/bcftools/query -entry test_bcftools_query_with_optional_files -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/bcftools/query/nextflow.config
   tags:
     - bcftools/query
     - bcftools
   files:
     - path: output/bcftools/out.txt
-      md5sum: 5a87e0865df2f0ab2884fc113ec2a70d
+      md5sum: 1785d1957ba7206df852d0689b91753f
+    - path: output/bcftools/versions.yml

--- a/tests/modules/nf-core/tabix/bgziptabix/main.nf
+++ b/tests/modules/nf-core/tabix/bgziptabix/main.nf
@@ -2,12 +2,15 @@
 
 nextflow.enable.dsl = 2
 
-include { TABIX_BGZIPTABIX } from '../../../../../modules/nf-core/tabix/bgziptabix/main.nf'
+include { TABIX_BGZIPTABIX as TABIX_BGZIPTABIX_TBI } from '../../../../../modules/nf-core/tabix/bgziptabix/main.nf'
+include { TABIX_BGZIPTABIX as TABIX_BGZIPTABIX_CSI } from '../../../../../modules/nf-core/tabix/bgziptabix/main.nf'
 
 workflow test_tabix_bgziptabix {
     input = [ [ id:'test' ], // meta map
               [ file(params.test_data['sarscov2']['illumina']['test_vcf'], checkIfExists: true) ]
             ]
 
-    TABIX_BGZIPTABIX ( input )
+    TABIX_BGZIPTABIX_TBI ( input )
+    TABIX_BGZIPTABIX_CSI ( input )
+
 }

--- a/tests/modules/nf-core/tabix/bgziptabix/nextflow.config
+++ b/tests/modules/nf-core/tabix/bgziptabix/nextflow.config
@@ -2,8 +2,12 @@ process {
 
     publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
 
-    withName: TABIX_BGZIPTABIX {
+    withName: TABIX_BGZIPTABIX_TBI {
         ext.args2 = '-p vcf'
+    }
+
+    withName: TABIX_BGZIPTABIX_CSI {
+        ext.args2 = '-p vcf --csi'
     }
 
 }

--- a/tests/modules/nf-core/tabix/bgziptabix/test.yml
+++ b/tests/modules/nf-core/tabix/bgziptabix/test.yml
@@ -5,6 +5,8 @@
     - tabix
   files:
     - path: output/tabix/test.vcf.gz
-      md5sum: fc178eb342a91dc0d1d568601ad8f8e2
+      md5sum: 02aff9ae43faf2594f28e2cf87b32ba9
     - path: output/tabix/test.vcf.gz.tbi
-      md5sum: 36e11bf96ed0af4a92caa91a68612d64
+      md5sum: d22e5b84e4fcd18792179f72e6da702e
+    - path: output/tabix/test.vcf.gz.csi
+      md5sum: 6f733d80ee760fcc8fdbe504a03f2640

--- a/tests/subworkflows/nf-core/vcf_annotate_ensemblvep_snpeff/main.nf
+++ b/tests/subworkflows/nf-core/vcf_annotate_ensemblvep_snpeff/main.nf
@@ -1,0 +1,170 @@
+#!/usr/bin/env nextflow
+
+nextflow.enable.dsl = 2
+
+include { VCF_ANNOTATE_ENSEMBLVEP_SNPEFF } from '../../../../subworkflows/nf-core/vcf_annotate_ensemblvep_snpeff/main.nf'
+
+workflow vcf_annotate_ensemblvep_snpeff_vep {
+    input = Channel.of([
+        [ id:'test' ], // meta map
+        file(params.test_data['sarscov2']['illumina']['test_vcf_gz'], checkIfExists: true),
+        file(params.test_data['sarscov2']['illumina']['test_vcf_gz_tbi'], checkIfExists: true),
+        []
+    ],[
+        [ id:'custom_test' ], // meta map
+        file(params.test_data['sarscov2']['illumina']['test2_vcf_gz'], checkIfExists: true),
+        file(params.test_data['sarscov2']['illumina']['test2_vcf_gz_tbi'], checkIfExists: true),
+        [
+            file(params.test_data['sarscov2']['illumina']['test3_vcf_gz'], checkIfExists: true),
+            file(params.test_data['sarscov2']['illumina']['test3_vcf_gz_tbi'], checkIfExists: true)
+        ]
+    ])
+
+    VCF_ANNOTATE_ENSEMBLVEP_SNPEFF (
+        input,
+        [[],[]],
+        "WBcel235",
+        "caenorhabditis_elegans",
+        "108",
+        [],
+        [],
+        [],
+        [],
+        ["ensemblvep"],
+        5
+    )
+}
+
+workflow vcf_annotate_ensemblvep_snpeff_snpeff {
+    input = Channel.of([
+        [ id:'test' ], // meta map
+        file(params.test_data['sarscov2']['illumina']['test_vcf_gz'], checkIfExists: true),
+        file(params.test_data['sarscov2']['illumina']['test_vcf_gz_tbi'], checkIfExists: true),
+        []
+    ],[
+        [ id:'custom_test' ], // meta map
+        file(params.test_data['sarscov2']['illumina']['test2_vcf_gz'], checkIfExists: true),
+        file(params.test_data['sarscov2']['illumina']['test2_vcf_gz_tbi'], checkIfExists: true),
+        [
+            file(params.test_data['sarscov2']['illumina']['test3_vcf_gz'], checkIfExists: true),
+            file(params.test_data['sarscov2']['illumina']['test3_vcf_gz_tbi'], checkIfExists: true)
+        ]
+    ])
+
+    VCF_ANNOTATE_ENSEMBLVEP_SNPEFF (
+        input,
+        [[],[]],
+        [],
+        [],
+        [],
+        [],
+        [],
+        "WBcel235.99",
+        [],
+        ["snpeff"],
+        5
+    )
+}
+
+workflow vcf_annotate_ensemblvep_snpeff_both {
+    input = Channel.of([
+        [ id:'test' ], // meta map
+        file(params.test_data['sarscov2']['illumina']['test_vcf_gz'], checkIfExists: true),
+        file(params.test_data['sarscov2']['illumina']['test_vcf_gz_tbi'], checkIfExists: true),
+        []
+    ],[
+        [ id:'custom_test' ], // meta map
+        file(params.test_data['sarscov2']['illumina']['test2_vcf_gz'], checkIfExists: true),
+        file(params.test_data['sarscov2']['illumina']['test2_vcf_gz_tbi'], checkIfExists: true),
+        [
+            file(params.test_data['sarscov2']['illumina']['test3_vcf_gz'], checkIfExists: true),
+            file(params.test_data['sarscov2']['illumina']['test3_vcf_gz_tbi'], checkIfExists: true)
+        ]
+    ])
+
+    VCF_ANNOTATE_ENSEMBLVEP_SNPEFF (
+        input,
+        [[],[]],
+        "WBcel235",
+        "caenorhabditis_elegans",
+        "108",
+        [],
+        [],
+        "WBcel235.99",
+        [],
+        ["snpeff", "ensemblvep"],
+        5
+    )
+}
+
+workflow vcf_annotate_ensemblvep_snpeff_large_chunks {
+    input = Channel.of([
+        [ id:'test' ], // meta map
+        file(params.test_data['sarscov2']['illumina']['test_vcf_gz'], checkIfExists: true),
+        file(params.test_data['sarscov2']['illumina']['test_vcf_gz_tbi'], checkIfExists: true),
+        []
+    ],[
+        [ id:'custom_test' ], // meta map
+        file(params.test_data['sarscov2']['illumina']['test2_vcf_gz'], checkIfExists: true),
+        file(params.test_data['sarscov2']['illumina']['test2_vcf_gz_tbi'], checkIfExists: true),
+        [
+            file(params.test_data['sarscov2']['illumina']['test3_vcf_gz'], checkIfExists: true),
+            file(params.test_data['sarscov2']['illumina']['test3_vcf_gz_tbi'], checkIfExists: true)
+        ]
+    ])
+
+    fasta = [
+        [id:"fasta"],
+        file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+    ]
+
+    VCF_ANNOTATE_ENSEMBLVEP_SNPEFF (
+        input,
+        fasta,
+        "WBcel235",
+        "caenorhabditis_elegans",
+        "108",
+        [],
+        [],
+        [],
+        [],
+        ["ensemblvep"],
+        100
+    )
+}
+
+workflow vcf_annotate_ensemblvep_snpeff_no_scatter {
+    input = Channel.of([
+        [ id:'test1' ], // meta map
+        file(params.test_data['sarscov2']['illumina']['test_vcf_gz'], checkIfExists: true),
+        file(params.test_data['sarscov2']['illumina']['test_vcf_gz_tbi'], checkIfExists: true),
+        []
+    ],[
+        [ id:'custom_test' ], // meta map
+        file(params.test_data['sarscov2']['illumina']['test2_vcf_gz'], checkIfExists: true),
+        file(params.test_data['sarscov2']['illumina']['test2_vcf_gz_tbi'], checkIfExists: true),
+        [
+            file(params.test_data['sarscov2']['illumina']['test3_vcf_gz'], checkIfExists: true),
+            file(params.test_data['sarscov2']['illumina']['test3_vcf_gz_tbi'], checkIfExists: true)
+        ]
+    ])
+
+    fasta = [
+        [id:"fasta"],
+        file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+    ]
+
+    VCF_ANNOTATE_ENSEMBLVEP_SNPEFF (
+        input,
+        fasta,
+        "WBcel235",
+        "caenorhabditis_elegans",
+        "108",
+        [],
+        [],
+        [],
+        [],
+        ["ensemblvep"],
+        []
+    )
+}

--- a/tests/subworkflows/nf-core/vcf_annotate_ensemblvep_snpeff/nextflow.config
+++ b/tests/subworkflows/nf-core/vcf_annotate_ensemblvep_snpeff/nextflow.config
@@ -1,0 +1,21 @@
+process {
+
+    publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
+
+    withName: ENSEMBLVEP_VEP {
+        container = 'docker.io/nfcore/vep:108.2.WBcel235'
+        ext.args = {[
+            "--vcf --offline",
+            meta.id.startsWith("custom_test") ? "--custom test3.vcf.gz,,vcf,exact,0,TOPMED" : ""
+        ].join(" ")}
+    }
+
+    withName: SNPEFF_SNPEFF {
+        container = 'docker.io/nfcore/snpeff:5.0.WBcel235'
+    }
+
+    withName: BCFTOOLS_CONCAT {
+        ext.prefix = { "${meta.id}_concat" }
+    }
+
+}

--- a/tests/subworkflows/nf-core/vcf_annotate_ensemblvep_snpeff/test.yml
+++ b/tests/subworkflows/nf-core/vcf_annotate_ensemblvep_snpeff/test.yml
@@ -1,0 +1,384 @@
+- name: vcf_annotate_ensemblvep_snpeff vcf_annotate_ensemblvep_snpeff_vep
+  command: nextflow run ./tests/subworkflows/nf-core/vcf_annotate_ensemblvep_snpeff -entry vcf_annotate_ensemblvep_snpeff_vep -c ./tests/config/nextflow.config
+  tags:
+    - bcftools
+    - bcftools/concat
+    - bcftools/pluginscatter
+    - bcftools/sort
+    - ensemblvep
+    - ensemblvep/vep
+    - snpeff
+    - snpeff/snpeff
+    - subworkflows
+    - subworkflows/vcf_annotate_ensemblvep_snpeff
+    - tabix
+    - tabix/tabix
+  files:
+    - path: output/bcftools/custom_test.vcf.gz
+      contains:
+        - "##fileformat=VCFv4.2"
+        - '##FILTER=<ID=PASS,Description="All filters passed">'
+    - path: output/bcftools/custom_test0.vcf
+      contains:
+        - "##fileformat=VCFv4.2"
+        - '##FILTER=<ID=PASS,Description="All filters passed">'
+    - path: output/bcftools/custom_test1.vcf
+      contains:
+        - "##fileformat=VCFv4.2"
+        - '##FILTER=<ID=PASS,Description="All filters passed">'
+    - path: output/bcftools/custom_test_concat.vcf.gz
+      contains:
+        - "##fileformat=VCFv4.2"
+        - '##FILTER=<ID=PASS,Description="All filters passed">'
+    - path: output/bcftools/test.vcf.gz
+      contains:
+        - "##fileformat=VCFv4.2"
+        - '##FILTER=<ID=PASS,Description="All filters passed">'
+    - path: output/bcftools/test0.vcf
+      contains:
+        - "##fileformat=VCFv4.2"
+        - '##FILTER=<ID=PASS,Description="All filters passed">'
+    - path: output/bcftools/test1.vcf
+      contains:
+        - "##fileformat=VCFv4.2"
+        - '##FILTER=<ID=PASS,Description="All filters passed">'
+    - path: output/bcftools/test_concat.vcf.gz
+      contains:
+        - "##fileformat=VCFv4.2"
+        - '##FILTER=<ID=PASS,Description="All filters passed">'
+    - path: output/ensemblvep/custom_test0_annotated.summary.html
+      contains:
+        - "<html>"
+        - "<head>"
+    - path: output/ensemblvep/custom_test0_annotated.vcf.gz
+      contains:
+        - "##fileformat=VCFv4.2"
+        - '##FILTER=<ID=PASS,Description="All filters passed">'
+    - path: output/ensemblvep/custom_test1_annotated.summary.html
+      contains:
+        - "<html>"
+        - "<head>"
+    - path: output/ensemblvep/custom_test1_annotated.vcf.gz
+      contains:
+        - "##fileformat=VCFv4.2"
+        - '##FILTER=<ID=PASS,Description="All filters passed">'
+    - path: output/ensemblvep/test0_annotated.summary.html
+      contains:
+        - "<html>"
+        - "<head>"
+    - path: output/ensemblvep/test0_annotated.vcf.gz
+      contains:
+        - "##fileformat=VCFv4.2"
+        - '##FILTER=<ID=PASS,Description="All filters passed">'
+    - path: output/ensemblvep/test1_annotated.summary.html
+      contains:
+        - "<html>"
+        - "<head>"
+    - path: output/ensemblvep/test1_annotated.vcf.gz
+      contains:
+        - "##fileformat=VCFv4.2"
+        - '##FILTER=<ID=PASS,Description="All filters passed">'
+    - path: output/tabix/custom_test.vcf.gz.tbi
+    - path: output/tabix/test.vcf.gz.tbi
+- name: vcf_annotate_ensemblvep_snpeff vcf_annotate_ensemblvep_snpeff_snpeff
+  command: nextflow run ./tests/subworkflows/nf-core/vcf_annotate_ensemblvep_snpeff -entry vcf_annotate_ensemblvep_snpeff_snpeff -c ./tests/config/nextflow.config
+  tags:
+    - bcftools
+    - bcftools/concat
+    - bcftools/pluginscatter
+    - bcftools/sort
+    - ensemblvep
+    - ensemblvep/vep
+    - snpeff
+    - snpeff/snpeff
+    - subworkflows
+    - subworkflows/vcf_annotate_ensemblvep_snpeff
+    - tabix
+    - tabix/tabix
+  files:
+    - path: output/bcftools/custom_test.vcf.gz
+      contains:
+        - "##fileformat=VCFv4.2"
+        - '##FILTER=<ID=PASS,Description="All filters passed">'
+    - path: output/bcftools/custom_test0.vcf
+      contains:
+        - "##fileformat=VCFv4.2"
+        - '##FILTER=<ID=PASS,Description="All filters passed">'
+    - path: output/bcftools/custom_test1.vcf
+      contains:
+        - "##fileformat=VCFv4.2"
+        - '##FILTER=<ID=PASS,Description="All filters passed">'
+    - path: output/bcftools/custom_test_concat.vcf.gz
+      contains:
+        - "##fileformat=VCFv4.2"
+        - '##FILTER=<ID=PASS,Description="All filters passed">'
+    - path: output/bcftools/test.vcf.gz
+      contains:
+        - "##fileformat=VCFv4.2"
+        - '##FILTER=<ID=PASS,Description="All filters passed">'
+    - path: output/bcftools/test0.vcf
+      contains:
+        - "##fileformat=VCFv4.2"
+        - '##FILTER=<ID=PASS,Description="All filters passed">'
+    - path: output/bcftools/test1.vcf
+      contains:
+        - "##fileformat=VCFv4.2"
+        - '##FILTER=<ID=PASS,Description="All filters passed">'
+    - path: output/bcftools/test_concat.vcf.gz
+      contains:
+        - "##fileformat=VCFv4.2"
+        - '##FILTER=<ID=PASS,Description="All filters passed">'
+    - path: output/snpeff/custom_test0_annotated.ann.vcf
+      contains:
+        - "##fileformat=VCFv4.2"
+        - '##FILTER=<ID=PASS,Description="All filters passed">'
+    - path: output/snpeff/custom_test0_annotated.csv
+      contains:
+        - "# Summary table"
+    - path: output/snpeff/custom_test0_annotated.genes.txt
+      md5sum: 130536bf0237d7f3f746d32aaa32840a
+    - path: output/snpeff/custom_test1_annotated.ann.vcf
+      contains:
+        - "##fileformat=VCFv4.2"
+        - '##FILTER=<ID=PASS,Description="All filters passed">'
+    - path: output/snpeff/custom_test1_annotated.csv
+      contains:
+        - "# Summary table"
+    - path: output/snpeff/custom_test1_annotated.genes.txt
+      md5sum: 130536bf0237d7f3f746d32aaa32840a
+    - path: output/snpeff/snpEff_summary.html
+      contains:
+        - '<style type="text/css">'
+    - path: output/snpeff/test0_annotated.ann.vcf
+      contains:
+        - "##fileformat=VCFv4.2"
+        - '##FILTER=<ID=PASS,Description="All filters passed">'
+    - path: output/snpeff/test0_annotated.csv
+      contains:
+        - "# Summary table"
+    - path: output/snpeff/test0_annotated.genes.txt
+      md5sum: 130536bf0237d7f3f746d32aaa32840a
+    - path: output/snpeff/test1_annotated.ann.vcf
+      contains:
+        - "##fileformat=VCFv4.2"
+        - '##FILTER=<ID=PASS,Description="All filters passed">'
+    - path: output/snpeff/test1_annotated.csv
+      contains:
+        - "# Summary table"
+    - path: output/snpeff/test1_annotated.genes.txt
+      md5sum: 130536bf0237d7f3f746d32aaa32840a
+    - path: output/tabix/custom_test.vcf.gz.tbi
+
+- name: vcf_annotate_ensemblvep_snpeff vcf_annotate_ensemblvep_snpeff_both
+  command: nextflow run ./tests/subworkflows/nf-core/vcf_annotate_ensemblvep_snpeff -entry vcf_annotate_ensemblvep_snpeff_both -c ./tests/config/nextflow.config
+  tags:
+    - bcftools
+    - bcftools/concat
+    - bcftools/pluginscatter
+    - bcftools/sort
+    - ensemblvep
+    - ensemblvep/vep
+    - snpeff
+    - snpeff/snpeff
+    - subworkflows
+    - subworkflows/vcf_annotate_ensemblvep_snpeff
+    - tabix
+    - tabix/tabix
+  files:
+    - path: output/bcftools/custom_test.vcf.gz
+      contains:
+        - "##fileformat=VCFv4.2"
+        - '##FILTER=<ID=PASS,Description="All filters passed">'
+    - path: output/bcftools/custom_test0.vcf
+      contains:
+        - "##fileformat=VCFv4.2"
+        - '##FILTER=<ID=PASS,Description="All filters passed">'
+    - path: output/bcftools/custom_test1.vcf
+      contains:
+        - "##fileformat=VCFv4.2"
+        - '##FILTER=<ID=PASS,Description="All filters passed">'
+    - path: output/bcftools/custom_test_concat.vcf.gz
+      contains:
+        - "##fileformat=VCFv4.2"
+        - '##FILTER=<ID=PASS,Description="All filters passed">'
+    - path: output/bcftools/test.vcf.gz
+      contains:
+        - "##fileformat=VCFv4.2"
+        - '##FILTER=<ID=PASS,Description="All filters passed">'
+    - path: output/bcftools/test0.vcf
+      contains:
+        - "##fileformat=VCFv4.2"
+        - '##FILTER=<ID=PASS,Description="All filters passed">'
+    - path: output/bcftools/test1.vcf
+      contains:
+        - "##fileformat=VCFv4.2"
+        - '##FILTER=<ID=PASS,Description="All filters passed">'
+    - path: output/bcftools/test_concat.vcf.gz
+      contains:
+        - "##fileformat=VCFv4.2"
+        - '##FILTER=<ID=PASS,Description="All filters passed">'
+    - path: output/ensemblvep/custom_test0_annotated.summary.html
+      contains:
+        - "<html>"
+        - "<head>"
+    - path: output/ensemblvep/custom_test0_annotated.vcf.gz
+      contains:
+        - "##fileformat=VCFv4.2"
+        - '##FILTER=<ID=PASS,Description="All filters passed">'
+    - path: output/ensemblvep/custom_test1_annotated.summary.html
+      contains:
+        - "<html>"
+        - "<head>"
+    - path: output/ensemblvep/custom_test1_annotated.vcf.gz
+      contains:
+        - "##fileformat=VCFv4.2"
+        - '##FILTER=<ID=PASS,Description="All filters passed">'
+    - path: output/ensemblvep/test0_annotated.summary.html
+      contains:
+        - "<html>"
+        - "<head>"
+    - path: output/ensemblvep/test0_annotated.vcf.gz
+      contains:
+        - "##fileformat=VCFv4.2"
+        - '##FILTER=<ID=PASS,Description="All filters passed">'
+    - path: output/ensemblvep/test1_annotated.summary.html
+      contains:
+        - "<html>"
+        - "<head>"
+    - path: output/ensemblvep/test1_annotated.vcf.gz
+      contains:
+        - "##fileformat=VCFv4.2"
+        - '##FILTER=<ID=PASS,Description="All filters passed">'
+    - path: output/snpeff/custom_test0_annotated.ann.vcf
+      contains:
+        - "##fileformat=VCFv4.2"
+        - '##FILTER=<ID=PASS,Description="All filters passed">'
+    - path: output/snpeff/custom_test0_annotated.csv
+      contains:
+        - "# Summary table"
+    - path: output/snpeff/custom_test0_annotated.genes.txt
+      md5sum: 130536bf0237d7f3f746d32aaa32840a
+    - path: output/snpeff/custom_test1_annotated.ann.vcf
+      contains:
+        - "##fileformat=VCFv4.2"
+        - '##FILTER=<ID=PASS,Description="All filters passed">'
+    - path: output/snpeff/custom_test1_annotated.csv
+      contains:
+        - "# Summary table"
+    - path: output/snpeff/custom_test1_annotated.genes.txt
+      md5sum: 130536bf0237d7f3f746d32aaa32840a
+    - path: output/snpeff/snpEff_summary.html
+      contains:
+        - '<style type="text/css">'
+    - path: output/snpeff/test0_annotated.ann.vcf
+      contains:
+        - "##fileformat=VCFv4.2"
+        - '##FILTER=<ID=PASS,Description="All filters passed">'
+    - path: output/snpeff/test0_annotated.csv
+      contains:
+        - "# Summary table"
+    - path: output/snpeff/test0_annotated.genes.txt
+      md5sum: 130536bf0237d7f3f746d32aaa32840a
+    - path: output/snpeff/test1_annotated.ann.vcf
+      contains:
+        - "##fileformat=VCFv4.2"
+        - '##FILTER=<ID=PASS,Description="All filters passed">'
+    - path: output/snpeff/test1_annotated.csv
+      contains:
+        - "# Summary table"
+    - path: output/snpeff/test1_annotated.genes.txt
+      md5sum: 130536bf0237d7f3f746d32aaa32840a
+    - path: output/tabix/custom_test.vcf.gz.tbi
+    - path: output/tabix/test.vcf.gz.tbi
+- name: vcf_annotate_ensemblvep_snpeff vcf_annotate_ensemblvep_snpeff_large_chunks
+  command: nextflow run ./tests/subworkflows/nf-core/vcf_annotate_ensemblvep_snpeff -entry vcf_annotate_ensemblvep_snpeff_large_chunks -c ./tests/config/nextflow.config
+  tags:
+    - bcftools
+    - bcftools/concat
+    - bcftools/pluginscatter
+    - bcftools/sort
+    - ensemblvep
+    - ensemblvep/vep
+    - snpeff
+    - snpeff/snpeff
+    - subworkflows
+    - subworkflows/vcf_annotate_ensemblvep_snpeff
+    - tabix
+    - tabix/tabix
+  files:
+    - path: output/bcftools/custom_test.vcf.gz
+      contains:
+        - "##fileformat=VCFv4.2"
+        - '##FILTER=<ID=PASS,Description="All filters passed">'
+    - path: output/bcftools/custom_test0.vcf
+      contains:
+        - "##fileformat=VCFv4.2"
+        - '##FILTER=<ID=PASS,Description="All filters passed">'
+    - path: output/bcftools/custom_test_concat.vcf.gz
+      contains:
+        - "##fileformat=VCFv4.2"
+        - '##FILTER=<ID=PASS,Description="All filters passed">'
+    - path: output/bcftools/test.vcf.gz
+      contains:
+        - "##fileformat=VCFv4.2"
+        - '##FILTER=<ID=PASS,Description="All filters passed">'
+    - path: output/bcftools/test0.vcf
+      contains:
+        - "##fileformat=VCFv4.2"
+        - '##FILTER=<ID=PASS,Description="All filters passed">'
+    - path: output/bcftools/test_concat.vcf.gz
+      contains:
+        - "##fileformat=VCFv4.2"
+        - '##FILTER=<ID=PASS,Description="All filters passed">'
+    - path: output/ensemblvep/custom_test0_annotated.summary.html
+      contains:
+        - "<html>"
+        - "<head>"
+    - path: output/ensemblvep/custom_test0_annotated.vcf.gz
+      contains:
+        - "##fileformat=VCFv4.2"
+        - '##FILTER=<ID=PASS,Description="All filters passed">'
+    - path: output/ensemblvep/test0_annotated.summary.html
+      contains:
+        - "<html>"
+        - "<head>"
+    - path: output/ensemblvep/test0_annotated.vcf.gz
+      contains:
+        - "##fileformat=VCFv4.2"
+        - '##FILTER=<ID=PASS,Description="All filters passed">'
+    - path: output/tabix/custom_test.vcf.gz.tbi
+    - path: output/tabix/test.vcf.gz.tbi
+- name: vcf_annotate_ensemblvep_snpeff vcf_annotate_ensemblvep_snpeff_no_scatter
+  command: nextflow run ./tests/subworkflows/nf-core/vcf_annotate_ensemblvep_snpeff -entry vcf_annotate_ensemblvep_snpeff_no_scatter -c ./tests/config/nextflow.config
+  tags:
+    - bcftools
+    - bcftools/concat
+    - bcftools/pluginscatter
+    - bcftools/sort
+    - ensemblvep
+    - ensemblvep/vep
+    - snpeff
+    - snpeff/snpeff
+    - subworkflows
+    - subworkflows/vcf_annotate_ensemblvep_snpeff
+    - tabix
+    - tabix/tabix
+  files:
+    - path: output/ensemblvep/custom_test.summary.html
+      contains:
+        - "<html>"
+        - "<head>"
+    - path: output/ensemblvep/custom_test.vcf.gz
+      contains:
+        - "##fileformat=VCFv4.2"
+        - '##FILTER=<ID=PASS,Description="All filters passed">'
+    - path: output/ensemblvep/test1.summary.html
+      contains:
+        - "<html>"
+        - "<head>"
+    - path: output/ensemblvep/test1.vcf.gz
+      contains:
+        - "##fileformat=VCFv4.2"
+        - '##FILTER=<ID=PASS,Description="All filters passed">'
+    - path: output/tabix/custom_test.vcf.gz.tbi
+    - path: output/tabix/test1.vcf.gz.tbi


### PR DESCRIPTION
I thought develop had the commits that were added to master in this PR #94, but apparently not. This should fix the differences between `upstream/master` and `develop` as well as resolve the difference between `master` and `develop`. 

I applied almost the exact process as in PR #94  

- branch from `origin/develop`
- Cherry picked missing commits: 
  - git cherry-pick 01b3b2509d76625b6d6cd613b349fb4777712a15
  - git cherry-pick 4b67587330aa81ab2f3f3b5b709adf21c6f6f8b2
- cherry pick the following commits as the missing ones above caused  `bcftools` and `bgziptabix` to be out of date `upstream/master`: 
  - git cherry-pick 591b71642820933dcb3c954c934b397bd00d8e5e
  - git cherry-pick b5cc8edd887e27c51a48387e34549d4405d9769f
